### PR TITLE
Add links to circus log files.

### DIFF
--- a/app/api/clog.py
+++ b/app/api/clog.py
@@ -3,6 +3,7 @@ import os
 from django.http import HttpResponse
 from django.conf import settings
 from app.models import BrewPiDevice
+from django.contrib import messages
 
 
 def get_device_log_plain(req, logfile, device_id, lines=100):
@@ -19,9 +20,9 @@ def get_device_log_plain(req, logfile, device_id, lines=100):
         logfile_fd = open(logfile_path)
         ret = tail(logfile_fd, int(lines))
         logfile_fd.close()
-    except IOError:
+    except IOError, e:
         # Generally if we hit this the log file doesn't exist
-        return False  # TODO - Return an empty string
+        return HttpResponse("Error opening {} logfile: {}".format(logfile, str(e)), status=500)
     return HttpResponse(ret, content_type="text/plain")
 
 
@@ -41,9 +42,9 @@ def get_stdout_as_json(req, device_id, lines=100):
         stdout_fd = open(stdout_log)
         ret = tail(stdout_fd, int(lines))
         stdout_fd.close()
-    except IOError:
+    except IOError, e:
         # Generally if we hit this the log file doesn't exist
-        return False  # TODO - Adjust this to return an empty JSON dict or something
+        return HttpResponse("Error opening logfile: {}".format(logfile, str(e)), status=500)
 
     new_ret = []
     # TODO: This is probably too hacky, but only matters if we end up using it :)

--- a/app/templates/site_help.html
+++ b/app/templates/site_help.html
@@ -15,6 +15,32 @@
 
 </p>
 
+<h3 class="page-header">Logs for troubleshooting</h3>
+<table class="table">
+  <thead class="thead-inverse">
+    <tr>
+      <th>#</th>
+      <th>Device Name</th>
+      <th>Stdout Log</th>
+      <th>Stderr Log</th>
+      <th>Status</th>
+      <td>Board Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for this_device in all_devices %}
+            <tr>
+                <th scope="row">{{ this_device.id }}</th>
+                <td>{{ this_device.device_name }}</td>
+                <td><a href="/api/log/stderr/{{ this_device.id }}/">log/dev-brewpi{{ this_device.id }}-stdout.log</a></td>
+                <td><a href="/api/log/stdout/{{ this_device.id }}/">log/dev-brewpi{{ this_device.id }}-stderr.log</a></td>
+                <td>{{ this_device.status }}</td>
+                <td>{{ this_device.board_type }}</td>
+            </tr>
+{% endfor %}
+  </tbody>
+</table>
+
 {% endblock %}
 
 {% block scripts %}{% endblock %}


### PR DESCRIPTION
 - Changed to display a friendlier error message and
   with a 500 http status code.

 - under site_help adds a table with links to logs.