### PR TITLE
Fix for issue 175

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1440,8 +1440,9 @@ class FermentationProfile(models.Model):
         interior_width = 0  # Interior width is the interior size that can be occupied by data (wall to wall)
 
         point_set = self.fermentationprofilepoint_set.order_by('ttl')
-
-        max_ttl_string = max([x.ttl_to_string() for x in point_set], key=len)
+        # We need to check there are any point_set yet
+        if len(point_set) < 0:
+            max_ttl_string = max([x.ttl_to_string() for x in point_set], key=len)
         max_ttl_length = len(max_ttl_string)
 
         # Set interior_width to the maximum interior width that we might need. This can be one of four things:


### PR DESCRIPTION
When a new fermentation is created profile point_set is empty and this patch implements
a check so that max is not run on an empty list.