### PR TITLE
Control Constants Communication Fixes

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1913,7 +1913,8 @@ class OldControlConstants(models.Model):
 
         if prior_control_constants is None:
             # Load the preexisting control constants from the controller
-            prior_control_constants = OldControlConstants().load_from_controller(controller)
+            prior_control_constants = OldControlConstants()
+            prior_control_constants.load_from_controller(controller)
 
         for this_field in self.firmware_field_list:
             # Now loop through and check each field to find out what changed

--- a/app/models.py
+++ b/app/models.py
@@ -1910,8 +1910,16 @@ class OldControlConstants(models.Model):
         :type controller: BrewPiDevice
         :return: boolean
         """
+
+        if prior_control_constants is None:
+            # Load the preexisting control constants from the controller
+            prior_control_constants = OldControlConstants.load_from_controller(controller)
+
         for this_field in self.firmware_field_list:
-            self.save_to_controller(controller, this_field)
+            # Now loop through and check each field to find out what changed
+            if getattr(self, this_field) != getattr(prior_control_constants, this_field):
+                # ...and only update those fields
+                self.save_to_controller(controller, this_field)
         return True
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -1913,7 +1913,7 @@ class OldControlConstants(models.Model):
 
         if prior_control_constants is None:
             # Load the preexisting control constants from the controller
-            prior_control_constants = OldControlConstants.load_from_controller(controller)
+            prior_control_constants = OldControlConstants().load_from_controller(controller)
 
         for this_field in self.firmware_field_list:
             # Now loop through and check each field to find out what changed


### PR DESCRIPTION
This commit reduces the communication required to send the control constants to the controller by only sending those constants that have explicitly changed from what was originally on the controller. 