### PR TITLE
Map "Log1Temp" to "RoomTemp" value

### DIFF
--- a/brewpi-script/brewpi.py
+++ b/brewpi-script/brewpi.py
@@ -396,6 +396,7 @@ prevTempJson = {
 
 def renameTempKey(key):
     rename = {
+        "Log1Temp": "RoomTemp", # Added for convenience, allows a configured OEM BrewPi to log room temp with Log1Temp
         "bt": "BeerTemp",
         "bs": "BeerSet",
         "ba": "BeerAnn",


### PR DESCRIPTION
This PR is opened not really expecting it to be merged, but to open a discussion about handling additional temperature inputs which the official BrewPi hardware can send. It might be a good time to figure out a solution that allows adding additional temperature targets, which can be selected in the "Assign" dialog when mapping pins.

In brewpi-www there are three additional temperature sensors but no dedicated room temperature sensor. These additional targets are named `Log1Temp` through `Log3Temp`. I'm guessing `Log1Temp` is the most obvious choice for a room temperature sensor, but it would be great to support additional sensors. For example, I would like to monitor:

* Compressor motor's temperature
* Temperature of back plate of fridge (possibly to some day prevent icing up when crashing beers?)

I'm not sure how to go about this, though. Obviously these have relation to the firmware - perhaps this is possible by making "temperature probes" an entity you create for a Device, and giving each "temperature probe" a "role" property that corresponds to the current `BeerTemp` etc. namings that you can then select?