### PR TITLE
Various adjustments to smaller screen layouts.

### DIFF
--- a/app/static/css/dashboard_revised.css
+++ b/app/static/css/dashboard_revised.css
@@ -183,3 +183,8 @@
 	margin: 0 auto;
 
 }
+
+.control-btn {
+    display: table;
+    margin: 15px auto;
+}

--- a/app/templates/device_dashboard.html
+++ b/app/templates/device_dashboard.html
@@ -77,7 +77,7 @@
     <!-- Start Dashboard Panels -->
     <div class="row">
 
-        <div class="col-md-3 col-xs-6">
+        <div class="col-md-3 col-sm-6 col-xs-12">
             <div class="dashpanel dashpanel-top bg-petermann">
                 <div class="dash-icon dash-icon-lg"><i class="fa fa-beer fa-fw"></i></div>
                 <div class="dashpanel-title">Beer Temp</div>
@@ -93,7 +93,7 @@
             </div>
         </div>
 
-        <div class="col-md-3 col-xs-6">
+        <div class="col-md-3 col-sm-6 col-xs-12">
             <div class="dashpanel dashpanel-top bg-amethyst" id="fridgeTempPanel">
                 <div class="dash-icon dash-icon-lg"><i class="fa fa-thermometer-full fa-fw"></i></div>
                 <div class="dashpanel-title">Fridge Temp</div>
@@ -120,7 +120,7 @@
 
         </div>
 
-        <div class="col-md-3 col-xs-6">
+        <div class="col-md-3 col-sm-6 col-xs-12">
             <div class="dashpanel dashpanel-top bg-concrete">
                 <div class="dash-icon dash-icon-lg"><i class="fa fa-bolt fa-fw"></i></div>
                 <div class="dashpanel-title">Control Mode</div>
@@ -148,7 +148,7 @@
             </div>
         </div>
 
-        <div class="col-md-3 col-xs-6">
+        <div class="col-md-3 col-sm-6 col-xs-12">
             <div class="dashpanel dashpanel-top bg-wet-asphalt">
                 <div class="dash-icon dash-icon-lg"><i class="fa fa-clock-o fa-fw"></i></div>
                 <div class="dashpanel-title">Log Interval</div>
@@ -183,66 +183,70 @@
                         </div>
                 </div>
                 <div class="panel-body">
-                        <div class="chart-legend-row row" id="beerTempRow">
-                            <div class="legend-label pull-left" style="padding-left: 10px;" id="beerTempLabel">
-                                <i class="fa fa-line-chart" style="color: {{ config.GRAPH_BEER_TEMP_COLOR }}" id="beer_temp_legend" onClick="toggle_graph_visibility(this)"></i>
-                                Beer Temp
-                            </div>
-                            <div class="legend-value pull-right" style="padding-right: 15px;" id="beerTempValue"></div>
-                        </div>
+                    <table class="table table-striped">
+                        <tbody>
+                            <tr id="beerTempRow">
+                                <td id="beerTempLabel">
+                                    <i class="fa fa-line-chart" style="color: {{ config.GRAPH_BEER_TEMP_COLOR }}" id="beer_temp_legend" onClick="toggle_graph_visibility(this)"></i>
+                                    Beer Temp
+                                </td>
+                                <td id="beerTempValue"></td>
+                            </tr>
 
-                        <div class="chart-legend-row row" id="beerSetRow">
-                            <div class="legend-label pull-left" style="padding-left: 10px;" id="beerSetLabel">
-                                <i class="fa fa-line-chart" style="color: {{ config.GRAPH_BEER_SET_COLOR }}" id="beer_set_legend" onClick="toggle_graph_visibility(this)"></i>
-                                Beer Setting
-                            </div>
-                            <div class="legend-value pull-right" style="padding-right: 15px;" id="beerSetValue"></div>
-                        </div>
+                            <tr id="beerSetRow">
+                                <td id="beerSetLabel">
+                                    <i class="fa fa-line-chart" style="color: {{ config.GRAPH_BEER_SET_COLOR }}" id="beer_set_legend" onClick="toggle_graph_visibility(this)"></i>
+                                    Beer Setting
+                                </td>
+                                <td id="beerSetValue"></td>
+                            </tr>
 
-                        <div class="chart-legend-row row" id="fridgeTempRow">
-                            <div class="legend-label pull-left" style="padding-left: 10px;" id="fridgeTempLabel">
-                                <i class="fa fa-line-chart" style="color: {{ config.GRAPH_FRIDGE_TEMP_COLOR }}" id="fridge_temp_legend" onClick="toggle_graph_visibility(this)"></i>
-                                Fridge Temp
-                            </div>
-                            <div class="legend-value pull-right" style="padding-right: 15px;" id="fridgeTempValue"></div>
-                        </div>
+                            <tr id="fridgeTempRow">
+                                <td id="fridgeTempLabel">
+                                    <i class="fa fa-line-chart" style="color: {{ config.GRAPH_FRIDGE_TEMP_COLOR }}" id="fridge_temp_legend" onClick="toggle_graph_visibility(this)"></i>
+                                    Fridge Temp
+                                </td>
+                                <td id="fridgeTempValue"></td>
+                            </tr>
 
-                        <div class="chart-legend-row row" id="fridgeSetRow">
-                            <div class="legend-label pull-left" style="padding-left: 10px;" id="fridgeSetLabel">
-                                <i class="fa fa-line-chart" style="color: {{ config.GRAPH_FRIDGE_SET_COLOR }}" id="fridge_set_legend" onClick="toggle_graph_visibility(this)"></i>
-                                Fridge Setting
-                            </div>
-                            <div class="legend-value pull-right" style="padding-right: 15px;" id="fridgeSetValue"></div>
-                        </div>
+                            <tr id="fridgeSetRow">
+                                <td id="fridgeSetLabel">
+                                    <i class="fa fa-line-chart" style="color: {{ config.GRAPH_FRIDGE_SET_COLOR }}" id="fridge_set_legend" onClick="toggle_graph_visibility(this)"></i>
+                                    Fridge Setting
+                                </td>
+                                <td id="fridgeSetValue"></td>
+                            </tr>
 
-                        <div class="chart-legend-row row" id="roomTempRow">
-                            <div class="legend-label pull-left" style="padding-left: 10px;" id="roomTempLabel">
-                                <i class="fa fa-line-chart" style="color: {{ config.GRAPH_ROOM_TEMP_COLOR }}" id="room_temp_legend" onClick="toggle_graph_visibility(this)"></i>
-                                Room Temp
-                            </div>
-                            <div class="legend-value pull-right" style="padding-right: 15px;" id="roomTempValue"></div>
-                        </div>
+                            <tr id="roomTempRow">
+                                <td id="roomTempLabel">
+                                    <i class="fa fa-line-chart" style="color: {{ config.GRAPH_ROOM_TEMP_COLOR }}" id="room_temp_legend" onClick="toggle_graph_visibility(this)"></i>
+                                    Room Temp
+                                </td>
+                                <td id="roomTempValue"></td>
+                            </tr>
 
-                        {# This is part of the specific gravity sensor support #}
-                        {% if beer.gravity_enabled %}
-                        <div class="chart-legend-row row" id="gravityRow">
-                            <div class="legend-label pull-left" style="padding-left: 10px;" id="gravityLabel">
-                                <i class="fa fa-line-chart" style="color: {{ config.GRAPH_FRIDGE_SET_COLOR }}" id="gravity_legend" onClick="toggle_graph_visibility(this)"></i>
-                                Gravity
-                            </div>
-                            <div class="legend-value pull-right" style="padding-right: 15px;" id="gravityValue"></div>
-                        </div>
+                            {# This is part of the specific gravity sensor support #}
+                            {% if beer.gravity_enabled %}
+                            <tr id="gravityRow">
+                                <td id="gravityLabel">
+                                    <i class="fa fa-line-chart" style="color: {{ config.GRAPH_FRIDGE_SET_COLOR }}" id="gravity_legend" onClick="toggle_graph_visibility(this)"></i>
+                                    Gravity
+                                </td>
+                                <td id="gravityValue"></td>
+                            </tr>
 
-                        <div class="chart-legend-row row" id="gravityTempRow">
-                            <div class="legend-label pull-left" style="padding-left: 10px;" id="gravityTempLabel">
-                                <i class="fa fa-line-chart" style="color: {{ config.GRAPH_ROOM_TEMP_COLOR }}" id="gravity_temp_legend" onClick="toggle_graph_visibility(this)"></i>
-                                Grav Sensor Temp
-                            </div>
-                            <div class="legend-value pull-right" style="padding-right: 15px;" id="gravityTempValue"></div>
-                        </div>
-                        {% endif %}
+                            <tr id="gravityTempRow">
+                                <td id="gravityTempLabel">
+                                    <i class="fa fa-line-chart" style="color: {{ config.GRAPH_ROOM_TEMP_COLOR }}" id="gravity_temp_legend" onClick="toggle_graph_visibility(this)"></i>
+                                    Grav Sensor Temp
+                                </td>
+                                <td id="gravityTempValue"></td>
+                            </tr>
+                            {% endif %}
+
+                        </tbody>
+                    </table>
                 </div>
-                <div class="panel-footer"></div>
 
             </div>
         </div>
@@ -253,14 +257,14 @@
     <!-- Begin Controls -->
     <div class="row" >
         <div class="col-md-4">
-            <button type="button" class="btn btn-lg btn-danger center" data-toggle="modal" data-target="#tempControl{{ active_device.id }}">Control Temperature</button>
+            <button type="button" class="btn btn-lg btn-danger control-btn" data-toggle="modal" data-target="#tempControl{{ active_device.id }}">Control Temperature</button>
         </div>
 
         <div class="col-md-4">
-            <button type="button" class="btn btn-lg btn-info center" data-toggle="modal" data-target="#beerModal">Control Logging</button>
+            <button type="button" class="btn btn-lg btn-info control-btn" data-toggle="modal" data-target="#beerModal">Control Logging</button>
         </div>
         <div class="col-md-4">
-            <button type="button" class="btn btn-lg btn-success center" data-toggle="modal" data-target="#beerLogModal">Load Prior Log</button>
+            <button type="button" class="btn btn-lg btn-success control-btn" data-toggle="modal" data-target="#beerLogModal">Load Prior Log</button>
         </div>
 
 

--- a/app/templates/sitewide/flat_ui_template.html
+++ b/app/templates/sitewide/flat_ui_template.html
@@ -5,7 +5,7 @@
         <title>{% block title %}Fermentrack Web Interface{% endblock %}</title>
         <meta name="description" content=""/>
 
-        <meta name="viewport" content="width=1000, initial-scale=1.0, maximum-scale=1.0">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link href="{% static "vendor/bootstrap/css/bootstrap.min.css" %}" rel="stylesheet">
         <link href="{% static "vendor/flat-ui/css/flat-ui.min.css" %}" rel="stylesheet">
         <link href="{% static "vendor/font-awesome/css/font-awesome.min.css" %}" rel="stylesheet">


### PR DESCRIPTION

This addresses a few of the issues I had seen when trying to use the dashboard on a smaller screen.  The most important change is setting the viewport `width=device-width`.  Without that, none of the column layouts for smaller screens were being used.

I also added `col-xs-12` on each of the panel items, so they would fill the whole row when used on a phone screen.  Very small screen were causing overlaps of icons in labels within the boxes.

Provided some top and bottom margins around the control buttons at the bottom of the screen.

And, changed the legend for temps to a table, instead of divs.  It is displaying tabular data, and bootstrap has the `striped` table rows which look nice.

This is a bit scattershot, but these were just some of the minor things that could update in a few hours.  Let me know if these is anything you don't want, or any follow on changes you'd like to make.

Below is a before and after:
![fermentrack_before](https://user-images.githubusercontent.com/2642026/46513603-621abf80-c827-11e8-826d-07e661a657f2.gif)


After:
![fermentrack_after](https://user-images.githubusercontent.com/2642026/46513609-6a72fa80-c827-11e8-939d-62098bd9a962.gif)
