### PR TITLE
Add gravity formula explanation to Tilt page

### DIFF
--- a/gravity/templates/gravity/gravity_manage.html
+++ b/gravity/templates/gravity/gravity_manage.html
@@ -190,7 +190,8 @@
         <p>
             Tilt Hydrometers measure & transmit a specific gravity directly, but this measurement can be slightly off
             from what the specific gravity actually is. Using a handful of calibration points, we fit an equation that
-            can be used to convert the Tilt-measured gravity to what we expect the actual gravity to be.
+            can be used to convert the Tilt-measured gravity to what we expect the actual gravity to be. Fermentrack 
+            performs the conversion using a quadratic formula in the format: gravity = bx^2 + cx + d, where x is the float angle.
         </p>
 
         <p>


### PR DESCRIPTION
The iSpindel management page explains the gravity formula but not the Tilt page. Text was copied to the Tilt page..