### PR TITLE
Update docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A full table of controllers/expected hardware availability is available [https:/
 
 ## Installation & Documentation
 
-Full documentation for Fermentrack (including complete installation instructions) is available at [https://docs.fermentrack.com/](https://docs.fermentrack.com/).
+Full documentation for Fermentrack (including complete installation instructions) is available at [https://fermentrack.readthedocs.io/](https://fermentrack.readthedocs.io/).
 
 
 ### Quick Installation Instructions


### PR DESCRIPTION
The two links were different but get to the same place.  The docs.fermentrack.com link generated a certs error due to name mismatch (cert expects readthedoics.io domain). If you ignore the error you wind up on a 404 page.  