### PR TITLE
Add fix instructions to Tilt tests

### DIFF
--- a/app/templates/github_trigger_upgrade.html
+++ b/app/templates/github_trigger_upgrade.html
@@ -77,7 +77,7 @@
 <p>Need to manually refresh the Python packages without upgrading? Click the below to trigger a refresh without pulling
     new code from GitHub</p>
 <p>
-    <a href="{% url "trigger_requirements_reload" %}" class="btn btn-primary">Refresh Python Packages</a>
+    <a href="{% url "trigger_requirements_reload" %}" class="btn btn-primary">Update/Install Missing Python Packages</a>
 </p>
 
 {% if allow_git_branch_switching %}

--- a/app/templates/github_trigger_upgrade.html
+++ b/app/templates/github_trigger_upgrade.html
@@ -74,6 +74,12 @@
 
 {% endif %}
 
+<p>Need to manually refresh the Python packages without upgrading? Click the below to trigger a refresh without pulling
+    new code from GitHub</p>
+<p>
+    <a href="{% url "trigger_requirements_reload" %}" class="btn btn-primary">Refresh Python Packages</a>
+</p>
+
 {% if allow_git_branch_switching %}
 
 <h3>Switch Branch</h3>

--- a/app/templates/trigger_requirements_reload.html
+++ b/app/templates/trigger_requirements_reload.html
@@ -1,0 +1,30 @@
+{% extends "sitewide/flat_ui_template.html" %}
+{% load custom_tags %}
+{% load static %}
+
+{% block title %}Reload Python Requirements{% endblock %}
+
+{% block header_scripts %}
+{% endblock %}
+
+
+{% block content %}
+    <h1>Reload Python Requirements</h1>
+
+    <p>
+        You have triggered a manual reload of the Python packages required by Fermentrack. Please wait several minutes
+        for this refresh to complete and for Fermentrack to relaunch before proceeding.
+    </p>
+
+    <p>
+        Once complete,  you can view the <a href="{% url "get_app_log" "text" "upgrade" "stderr" %}">upgrade log</a> to see
+        what was installed/updated.
+    </p>
+
+
+{% endblock %}
+
+
+
+{% block scripts %}
+{% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -540,6 +540,20 @@ def github_trigger_force_upgrade(request):
 
 
 
+@login_required
+@site_is_configured
+def trigger_requirements_reload(request):
+    # TODO - Add permission check here
+
+    # All that this view does is trigger the utils/fix_python_requirements.sh shell script and return a message letting
+    # the user know that Fermentrack will take a few minutes to restart.
+    cmd = "nohup utils/fix_python_requirements.sh &"
+    messages.success(request, "Triggered a reload of your Python packages")
+    subprocess.call(cmd, shell=True)
+
+    return render(request, template_name="trigger_requirements_reload.html", context={})
+
+
 def login(request, next=None):
     if not next:
         if 'next' in request.GET:

--- a/docs/source/gravitysensors/tilt.rst
+++ b/docs/source/gravitysensors/tilt.rst
@@ -103,7 +103,12 @@ Although all Python packages should be automatically installed as part of the in
 packages come out of sync for a variety of reasons. If you are missing packages they will need to be installed for
 Fermentrack to properly interface with your Tilt.
 
-.. todo:: Enrich this with steps for resolving missing Python packages
+A manual refresh of the Python packages can be triggered from the GitHub upgrade page without updating Fermentrack from
+GitHub. To trigger a refresh:
 
+#. Log into Fermentrack
+#. Click the 'gear' icon in the upper right hand corner of the page
+#. Click 'Update from GitHub'
+#. Click the 'Refresh Python Packages' button
 
 

--- a/docs/source/gravitysensors/tilt.rst
+++ b/docs/source/gravitysensors/tilt.rst
@@ -109,6 +109,6 @@ GitHub. To trigger a refresh:
 #. Log into Fermentrack
 #. Click the 'gear' icon in the upper right hand corner of the page
 #. Click 'Update from GitHub'
-#. Click the 'Refresh Python Packages' button
+#. Click the 'Update/Install Missing Python Packages' button
 
 

--- a/fermentrack_django/urls.py
+++ b/fermentrack_django/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
 
     url(r'^upgrade/$', app.views.github_trigger_upgrade, name='github_trigger_upgrade'),
     url(r'^upgrade/force/$', app.views.github_trigger_force_upgrade, name='github_trigger_force_upgrade'),
+    url(r'^upgrade/reload/$', app.views.trigger_requirements_reload, name='trigger_requirements_reload'),
 
     ### Device Views
     url(r'^devices/$', app.views.device_lcd_list, name='device_lcd_list'),

--- a/gravity/templates/gravity/gravity_manage_tilt.html
+++ b/gravity/templates/gravity/gravity_manage_tilt.html
@@ -143,7 +143,11 @@
 
         <h2>Troubleshoot Tilt Connection</h2>
 
-        <p>If you are having difficulty getting/keeping your Tilt connected, <a href="{% url "gravity_tilt_test" %}">click here</a> to debug the connection.</p>
+        <p>If you are having difficulty getting/keeping your Bluetooth Tilt connected, click the button below to launch the Tilt test script.</p>
+
+        <p>
+            <a href="{% url "gravity_tilt_test" %}" class="btn btn-primary">Troubleshoot Tilt Connection</a>
+        </p>
 
     {% endif %}
 

--- a/gravity/templates/gravity/gravity_tilt_test.html
+++ b/gravity/templates/gravity/gravity_tilt_test.html
@@ -104,13 +104,26 @@
         </table>
 
         {% if not has_python_packages %}
+
             <p>
-                <a href="{% url "trigger_requirements_reload" %}" class="btn btn-primary">Refresh Python Packages</a>
+                One or more of the Python packages required for Fermentrack's Tilt support to function are either
+                missing or at an incorrect version.
+                {% if not has_apt_packages %}
+                    This may be caused by missing system packages. Before proceeding, please ensure that all required
+                    system packages (see the earlier test) are installed.
+                {% endif %}
+                The easiest way to resolve this is to trigger a manual refresh of the Python requirements. To do this,
+                click the button below. If this does not resolve your missing packages check the
+                <a href="{% url "get_app_log" "text" "upgrade" "stderr" %}">upgrade log</a> to see what is happening.
+            </p>
+
+            <p>
+                <a href="{% url "trigger_requirements_reload" %}" class="btn btn-primary">Update/Install Missing Python Packages</a>
             </p>
         {% endif %}
 
     {% else %}
-        <h4>Python 'packaging' module is not available - Test cannot run!</h4>
+        <h4 style="color: darkred">Python 'packaging' module is not available - Test cannot run!</h4>
         <p>
             This is a fairly serious error, as it implies that your python packages are not being kept up-to-date.
             If there are missing system packages (above) resolve those before proceeding. Next, attempt a
@@ -119,7 +132,7 @@
             <a href="{% url "get_app_log" "text" "upgrade" "stderr" %}">upgrade log</a> to see what is happening.
         </p>
         <p>
-            <a href="{% url "trigger_requirements_reload" %}" class="btn btn-primary">Refresh Python Packages</a>
+            <a href="{% url "trigger_requirements_reload" %}" class="btn btn-primary">Update/Install Missing Python Packages</a>
         </p>
 
     {% endif %}

--- a/gravity/templates/gravity/gravity_tilt_test.html
+++ b/gravity/templates/gravity/gravity_tilt_test.html
@@ -25,8 +25,8 @@
 
         <table class="table table-hover">
             <tr>
-                <td>Package Name</td>
-                <td>OK?</td>
+                <th>Package Name</th>
+                <th>OK?</th>
             </tr>
 
             {% for test_result in apt_test_results %}
@@ -37,6 +37,19 @@
             {% endfor %}
 
         </table>
+
+        {% if not has_apt_packages %}
+            <h5 style="color: darkred">NOTE - Fix the above errors first and then re-run the tests before proceeding</h5>
+
+            <p>
+            Several of the system packages listed above are required for all of the Python packages to install. If you
+            do not first install the missing system packages you may be unable to fix other errors that appear on this
+            page. Thankfully, installing these missing packages is pretty simple. Information on how to resolve this
+            can be found in the <a href="http://docs.fermentrack.com/en/dev/gravitysensors/tilt.html#fixing-missing-system-packages">Fermentrack documentation.</a>
+            </p>
+        {% endif %}{# has_apt_packages #}
+
+
     {% else %}
             <h4>Unable to locate the software necessary to check system packages</h4>
             <p>
@@ -44,6 +57,8 @@
                 on another operating system, you're unfortunately on your own for this test.
             </p>
     {% endif %}{# has_apt #}
+
+
 
 
     <h3>Python Packages</h3>
@@ -72,10 +87,10 @@
 
         <table class="table table-hover">
             <tr>
-                <td>Package Name</td>
-                <td>Required Version</td>
-                <td>Installed Version</td>
-                <td>OK?</td>
+                <th>Package Name</th>
+                <th>Required Version</th>
+                <th>Installed Version</th>
+                <th>OK?</th>
             </tr>
 
             {% for test_result in python_test_results %}
@@ -87,11 +102,24 @@
             </tr>
             {% endfor %}
         </table>
+
+        {% if not has_python_packages %}
+            <p>
+                <a href="{% url "trigger_requirements_reload" %}" class="btn btn-primary">Refresh Python Packages</a>
+            </p>
+        {% endif %}
+
     {% else %}
         <h4>Python 'packaging' module is not available - Test cannot run!</h4>
         <p>
             This is a fairly serious error, as it implies that your python packages are not being kept up-to-date.
-        Check the <a href="{% url "get_app_log" "text" "upgrade" "stderr" %}">upgrade log</a> to see what is happening.
+            If there are missing system packages (above) resolve those before proceeding. Next, attempt a
+            manual refresh (below) of the Python requirements to see if the 'packaging' module can be installed. If
+            neither of these resolve this issue, check the
+            <a href="{% url "get_app_log" "text" "upgrade" "stderr" %}">upgrade log</a> to see what is happening.
+        </p>
+        <p>
+            <a href="{% url "trigger_requirements_reload" %}" class="btn btn-primary">Refresh Python Packages</a>
         </p>
 
     {% endif %}

--- a/utils/fix_python_requirements.sh
+++ b/utils/fix_python_requirements.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Defaults
+SILENT=0
+CIRCUSCTL="python3 -m circus.circusctl --timeout 10"
+
+# Colors (for printinfo/error/warn below)
+green=$(tput setaf 76)
+red=$(tput setaf 1)
+tan=$(tput setaf 3)
+reset=$(tput sgr0)
+
+
+
+printinfo() {
+    if [ ${SILENT} -eq 0 ]
+    then
+        printf "::: ${green}%s${reset}\n" "$@"
+    fi
+}
+
+
+printwarn() {
+    if [ ${SILENT} -eq 0 ]
+    then
+        printf "${tan}*** WARNING: %s${reset}\n" "$@"
+    fi
+}
+
+
+printerror() {
+    if [ ${SILENT} -eq 0 ]
+    then
+        printf "${red}*** ERROR: %s${reset}\n" "$@"
+    fi
+}
+
+
+
+exec > >(tee -i log/upgrade.log)
+
+
+printinfo "Re-installing Python packages from requirements.txt"
+# First, launch the virtualenv
+source ~/venv/bin/activate  # Assuming the directory based on a normal install with Fermentrack-tools
+
+# Given that this script can be called by the webapp proper, give it 2 seconds to finish sending a reply to the
+# user if he/she initiated an upgrade through the webapp.
+printinfo "Waiting 1 second for Fermentrack to send updates if triggered from the web..."
+sleep 1s
+
+# Next, kill the running Fermentrack instance using circus
+printinfo "Stopping circus..."
+$CIRCUSCTL stop &>> log/upgrade.log
+
+# Install everything from requirements.txt
+printinfo "Updating requirements via pip3..."
+pip3 install -U -r requirements.txt --upgrade &>> log/upgrade.log
+
+# Migrate to create/adjust anything necessary in the database
+printinfo "Running manage.py migrate..."
+python3 manage.py migrate &>> log/upgrade.log
+
+# Migrate to create/adjust anything necessary in the database
+printinfo "Running manage.py collectstatic..."
+python3 manage.py collectstatic --noinput >> /dev/null
+
+
+# Finally, relaunch the Fermentrack instance using circus
+printinfo "Relaunching circus..."
+$CIRCUSCTL reloadconfig &>> log/upgrade.log
+$CIRCUSCTL start &>> log/upgrade.log
+printinfo "Complete!"


### PR DESCRIPTION
The Tilt tests seem to be doing their job - but after they identified an issue, they weren't providing the user with any guidance on how to resolve it. This pull request adds links to the documentation for how to resolve missing system packages as well as a shell script that will manually refresh the Python packages from requirements.txt if required.