### PR TITLE
Improve TiltBridge Configuration Support

### DIFF
--- a/app/templates/site_help.html
+++ b/app/templates/site_help.html
@@ -106,6 +106,13 @@
   </tbody>
 </table>
 
+
+<h4>Other troubleshooting tools</h4>
+
+<p>
+    <a href="{% url "gravity_tilt_test" %}" class="btn btn-primary">Troubleshoot Tilt/Bluetooth Support</a>
+</p>
+
 {% endblock %}
 
 {% block scripts %}{% endblock %}

--- a/docs/source/develop/changelog.rst
+++ b/docs/source/develop/changelog.rst
@@ -17,6 +17,7 @@ Added
 - Store the exact last time that a message was received from a Tilt to Redis
 - Add sentry support to tilt_monitor_aio.py
 - Added "debug" scripts for bluetooth Tilt connections
+- Added TiltBridge connection settings to Tilt management page
 
 
 

--- a/gravity/templates/gravity/gravity_manage_tilt.html
+++ b/gravity/templates/gravity/gravity_manage_tilt.html
@@ -151,6 +151,31 @@
 
     {% endif %}
 
+    {% if active_device.tilt_configuration.connection_type == "Bridge" %}
+        <h2>TiltBridge Configuration</h2>
+
+        <p>
+        In order for your TiltBridge to communicate with Fermentrack, it needs to be told where Fermentrack can be
+        reached on  your network. If the mDNS ID specified above is correct, this can be done automatically by
+        Fermentrack, or you can set this manually on the TiltBridge's configuration page.
+        </p>
+
+        <div class="row">
+            <div class="col-lg-5 col-sm-9 col-xs-12">
+                <table class="table">
+                    <tr>
+                        <th>Fermentrack URL (copy to TiltBridge)</th>
+                        <td>{{ fermentrack_url }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+
+        <p>
+            <a href="{% url "gravity_tiltbridge_set_url" active_device.tilt_configuration.tiltbridge.id active_device.id %}" class="btn btn-primary">Update TiltBridge Automatically</a>
+        </p>
+    {% endif %}
+
 
     <!-- Modal -->
     <div class="modal fade" id="calibrationModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">

--- a/gravity/templates/gravity/gravity_manage_tilt.html
+++ b/gravity/templates/gravity/gravity_manage_tilt.html
@@ -26,7 +26,9 @@
                         </tr>
                         <tr>
                             <td>Connection Type</td>
-                            <td>{{ active_device.tilt_configuration.connection_type }}</td>
+                            <td>
+                                {% if active_device.tilt_configuration.connection_type == "Bridge" %}TiltBridge{% elif active_device.tilt_configuration.connection_type == "Bluetooth" %}Bluetooth{% else %}Unknown{% endif %}
+                            </td>
                         </tr>
                         <tr>
                             <td>Smoothing Window (Readings)</td>
@@ -172,7 +174,7 @@
         </div>
 
         <p>
-            <a href="{% url "gravity_tiltbridge_set_url" active_device.tilt_configuration.tiltbridge.id active_device.id %}" class="btn btn-primary">Update TiltBridge Automatically</a>
+            <a href="{% url "gravity_tiltbridge_set_url" active_device.tilt_configuration.tiltbridge.mdns_id active_device.id %}" class="btn btn-primary">Update TiltBridge Automatically</a>
         </p>
     {% endif %}
 

--- a/gravity/templates/gravity/gravity_tilt_test.html
+++ b/gravity/templates/gravity/gravity_tilt_test.html
@@ -24,10 +24,12 @@
         {% endif %}{# has_apt_packages #}
 
         <table class="table table-hover">
-            <tr>
-                <th>Package Name</th>
-                <th>OK?</th>
-            </tr>
+            <thead>
+                <tr>
+                    <th>Package Name</th>
+                    <th>OK?</th>
+                </tr>
+            </thead>
 
             {% for test_result in apt_test_results %}
                 <tr>
@@ -86,12 +88,14 @@
 
 
         <table class="table table-hover">
-            <tr>
-                <th>Package Name</th>
-                <th>Required Version</th>
-                <th>Installed Version</th>
-                <th>OK?</th>
-            </tr>
+            <thead>
+                <tr>
+                    <th>Package Name</th>
+                    <th>Required Version</th>
+                    <th>Installed Version</th>
+                    <th>OK?</th>
+                </tr>
+            </thead>
 
             {% for test_result in python_test_results %}
             <tr>

--- a/gravity/urls.py
+++ b/gravity/urls.py
@@ -63,6 +63,8 @@ gravity_urlpatterns = [
 
     # TiltBridge specific views
     url(r'^gravity/tiltbridge/add/$', gravity.views_tilt.gravity_tiltbridge_add, name='gravity_tiltbridge_add'),
+    url(r'^gravity/tiltbridge/update/(?P<tiltbridge_id>[A-Za-z0-9]{1,20})/set_url/$', gravity.views_tilt.gravity_tiltbridge_set_url, name='gravity_tiltbridge_set_url'),
+    url(r'^gravity/tiltbridge/update/(?P<tiltbridge_id>[A-Za-z0-9]{1,20})/set_url/(?P<sensor_id>[A-Za-z0-9]{1,20})$', gravity.views_tilt.gravity_tiltbridge_set_url, name='gravity_tiltbridge_set_url'),
     url(r'^gravity/tiltbridge/urlerror/(?P<tiltbridge_id>[A-Za-z0-9]+)/$', gravity.views_tilt.gravity_tiltbridge_urlerror, name='gravity_tiltbridge_urlerror'),
 
 ]

--- a/gravity/views.py
+++ b/gravity/views.py
@@ -15,7 +15,7 @@ from gravity.models import GravitySensor, GravityLog, TiltConfiguration, TiltTem
 
 from app.decorators import site_is_configured, login_if_required_for_dashboard, gravity_support_enabled
 
-import os, subprocess, datetime, pytz, json, logging, sys
+import os, subprocess, datetime, pytz, json, logging, sys, socket
 
 import gravity.forms as forms
 
@@ -532,6 +532,24 @@ def gravity_manage(request, sensor_id):
         context['tilt_calibration_points'] = calibration_points
         tilt_calibration_form = forms.TiltGravityCalibrationPointForm(initial={'sensor': sensor.tilt_configuration})
         context['tilt_calibration_form'] = tilt_calibration_form
+
+        if sensor.tilt_configuration.connection_type == TiltConfiguration.CONNECTION_BRIDGE:
+            # For TiltBridges, we want to give the user the info necessary to configure the device to communicate with
+            # Fermentrack
+            fermentrack_host = request.META['HTTP_HOST']
+            try:
+                if ":" in fermentrack_host:
+                    fermentrack_host = fermentrack_host[:fermentrack_host.find(":")]
+                ais = socket.getaddrinfo(fermentrack_host, 0, 0, 0, 0)
+                ip_list = [result[-1][0] for result in ais]
+                ip_list = list(set(ip_list))
+                resolved_address = ip_list[0]
+                fermentrack_url = "http://{}/tiltbridge/".format(resolved_address)
+            except:
+                # For some reason we failed to resolve the IP address of Fermentrack
+                fermentrack_url = "<Error - Unable to resolve Fermentrack IP address>"
+            context['fermentrack_url'] = fermentrack_url
+
 
         return render(request, template_name='gravity/gravity_manage_tilt.html', context=context)
     else:

--- a/gravity/views_tilt.py
+++ b/gravity/views_tilt.py
@@ -481,7 +481,7 @@ def gravity_tiltbridge_set_url(request, tiltbridge_id, sensor_id=None):
     if this_tiltbridge.update_fermentrack_url_on_tiltbridge(fermentrack_host):
         messages.success(request, u"Updated Fermentrack URL on TiltBridge '{}'".format(this_tiltbridge.name))
     else:
-        messages.error(request, u"Unable to automatically update Fermentrack URL on TiltBridge {}".format(this_tiltbridge.name))
+        messages.error(request, u"Unable to automatically update Fermentrack URL at {}.local".format(this_tiltbridge.mdns_id))
 
     # If we were passed a sensor ID, we want to return to the management screen for that ID.
     if sensor_id is not None:

--- a/gravity/views_tilt.py
+++ b/gravity/views_tilt.py
@@ -467,9 +467,9 @@ def gravity_tiltbridge_set_url(request, tiltbridge_id, sensor_id=None):
     #     return redirect("/")
 
     try:
-        this_tiltbridge = TiltBridge.objects.get(id=tiltbridge_id)
+        this_tiltbridge = TiltBridge.objects.get(mdns_id=tiltbridge_id)
     except ObjectDoesNotExist:
-        messages.error(request, "Unable to locate TiltBridge with ID {}".format(tiltbridge_id))
+        messages.error(request, "Unable to locate TiltBridge with mDNS ID {}".format(tiltbridge_id))
         if sensor_id is not None:
             return redirect("gravity_manage", sensor_id=sensor_id)
         else:

--- a/gravity/views_tilt.py
+++ b/gravity/views_tilt.py
@@ -458,6 +458,37 @@ def gravity_tiltbridge_add(request):
     return render(request, template_name='gravity/gravity_tiltbridge_add.html',
                   context={'form': form, 'available_devices': available_devices,})
 
+@login_required
+@site_is_configured
+def gravity_tiltbridge_set_url(request, tiltbridge_id, sensor_id=None):
+    # TODO - Add user permissioning
+    # if not request.user.has_perm('app.edit_device'):
+    #     messages.error(request, 'Your account is not permissioned to edit devices. Please contact an admin')
+    #     return redirect("/")
+
+    try:
+        this_tiltbridge = TiltBridge.objects.get(id=tiltbridge_id)
+    except ObjectDoesNotExist:
+        messages.error(request, "Unable to locate TiltBridge with ID {}".format(tiltbridge_id))
+        if sensor_id is not None:
+            return redirect("gravity_manage", sensor_id=sensor_id)
+        else:
+            return redirect("siteroot")
+
+
+    fermentrack_host = request.META['HTTP_HOST']
+
+    if this_tiltbridge.update_fermentrack_url_on_tiltbridge(fermentrack_host):
+        messages.success(request, u"Updated Fermentrack URL on TiltBridge '{}'".format(this_tiltbridge.name))
+    else:
+        messages.error(request, u"Unable to automatically update Fermentrack URL on TiltBridge {}".format(this_tiltbridge.name))
+
+    # If we were passed a sensor ID, we want to return to the management screen for that ID.
+    if sensor_id is not None:
+        return redirect("gravity_manage", sensor_id=sensor_id)
+    else:
+        return redirect("siteroot")
+
 
 @login_required
 @site_is_configured


### PR DESCRIPTION
This pull request adds configuration guidance for TiltBridges to gravity sensor device dashboards. This also adds a workflow by which an automatic configuration update can be sent to the TiltBridge from Fermentrack.