### PR TITLE
Warning about python version on Master branch

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -66,7 +66,7 @@ def error_notifications(request):
     # TODO - Remove this after June 1st release
     if sys.version_info < (3, 7):
         messages.error(request, "You are currently running Python {}.{} ".format(sys.version_info.major, sys.version_info.minor) +
-                         "which will no longer be supported by Fermentrack with the next release (which is due June 1st). " +
+                         "which will no longer be supported by Fermentrack with the next release (due <b>June 5th</b>). " +
                          'To learn more (including how to fix this) read <a href="https://github.com/thorrak/fermentrack/issues/463">this issue on GitHub</a>.')
 
     # This is a good idea to do, but unfortunately sshwarn doesn't get removed when the password is changed, only when

--- a/app/views.py
+++ b/app/views.py
@@ -65,9 +65,9 @@ def error_notifications(request):
 
     # TODO - Remove this after June 1st release
     if sys.version_info < (3, 7):
-        messages.error(request, "You are currently running Python {} ".format(sys.version_info) +
-                         "which will no longer be supported by Fermentrack with the next release which is due June 1st. " +
-                         'To learn more (including how to upgrade to Python 3.7) read <a href="https://github.com/thorrak/fermentrack/issues/463">this issue on GitHub</a>.')
+        messages.error(request, "You are currently running Python {}.{} ".format(sys.version_info.major, sys.version_info.minor) +
+                         "which will no longer be supported by Fermentrack with the next release (which is due June 1st). " +
+                         'To learn more (including how to fix this) read <a href="https://github.com/thorrak/fermentrack/issues/463">this issue on GitHub</a>.')
 
     # This is a good idea to do, but unfortunately sshwarn doesn't get removed when the password is changed, only when
     # the user logs in a second time. Once I have time to make a "help" page for this, I'll readd this check

--- a/app/views.py
+++ b/app/views.py
@@ -63,6 +63,12 @@ def error_notifications(request):
                                      "branch, but you are currently using the {} branch. ".format(settings.GIT_BRANCH) +
                                      'Click <a href="/upgrade">here</a> to update to the correct branch.')
 
+    # TODO - Remove this after June 1st release
+    if sys.version_info < (3, 7):
+        messages.error(request, "You are currently running Python {} ".format(sys.version_info) +
+                         "which will no longer be supported by Fermentrack with the next release which is due June 1st. " +
+                         'To learn more (including how to upgrade to Python 3.7) read <a href="https://github.com/thorrak/fermentrack/issues/463">this issue on GitHub</a>.')
+
     # This is a good idea to do, but unfortunately sshwarn doesn't get removed when the password is changed, only when
     # the user logs in a second time. Once I have time to make a "help" page for this, I'll readd this check
     # TODO - Readd this check

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ requests        # for loading firmware data from websites
 esptool         # for flashing ESP8266 devices
 packaging~=17.1 # for testing requirements in the Tilt tests
 
+pyzmq~=19.0.1 --no-binary=pyzmq  # The wheel for pyzmq periodically has issues for Raspbian installs
+
 # Reminder - Update the version checks in gravity/tilt/tilt_tests.py when changing versions for the BT/Tilt pkgs
 redis==3.4.1           # for huey & gravity sensor support
 PyBluez==0.23          # for gravity sensor support


### PR DESCRIPTION
This PR adds a warning to the Master branch about the upcoming PR which will break installations on Python 3.5 (meaning - most installations on Stretch)