### PR TITLE
Additional fixes for Django Foreign Key issues

### DIFF
--- a/app/management/commands/migrate_no_fk.py
+++ b/app/management/commands/migrate_no_fk.py
@@ -1,0 +1,235 @@
+from importlib import import_module
+
+from django.apps import apps
+from django.core.management.base import (
+    BaseCommand, CommandError, no_translations,
+)
+from django.core.management.sql import (
+    emit_post_migrate_signal, emit_pre_migrate_signal,
+)
+from django.db import connections
+from django.db.migrations.autodetector import MigrationAutodetector
+from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.loader import AmbiguityError
+from django.db.migrations.state import ModelState, ProjectState
+from django.utils.module_loading import module_has_submodule
+
+
+from django.core.management.commands.migrate import Command as MigrateCommand
+from django.db.backends.sqlite3.schema import DatabaseSchemaEditor, BaseDatabaseSchemaEditor
+
+
+class Command(MigrateCommand):
+    help = "Same as a standard migrate, but disables FK checks for SQLite"
+
+    @no_translations
+    def handle(self, *args, **options):
+        # We're monkey patching the __exit__ method of DatabaseSchemaEditor because it reenables constraint checking
+        # which we explicitly DO NOT want to do. The problem is that without patching this if multiple tables have
+        # incorrect foreign key constraints you can't fix one at a time - you have to fix both simultaneously (which
+        # Django doesn't support). Fun times.
+        DatabaseSchemaEditor.__exit__ = BaseDatabaseSchemaEditor.__exit__
+
+
+        # I would MUCH prefer to do this by calling super().handle(), but we have to edit the "connection" object within
+        # migrate to make this work. Instead, below is the code as copied from django.core.management.commands.migrate.handle()
+        # aside from the handful of lines between rows 55 and 60.
+
+
+        self.verbosity = options['verbosity']
+        self.interactive = options['interactive']
+
+        # Import the 'management' module within each installed app, to register
+        # dispatcher events.
+        for app_config in apps.get_app_configs():
+            if module_has_submodule(app_config.module, "management"):
+                import_module('.management', app_config.name)
+
+        # Get the database we're operating from
+        db = options['database']
+        connection = connections[db]
+
+        # Hook for backends needing any database preparation
+        connection.prepare_database()
+
+        #### The below five lines of code are the new additions in migrate_no_fk
+        try:
+            constraint_check = connection.disable_constraint_checking()
+        except:
+            connection.connection = connection.connect()
+            constraint_check = connection.disable_constraint_checking()
+        #### End additions!
+
+        # Work out which apps have migrations and which do not
+        executor = MigrationExecutor(connection, self.migration_progress_callback)
+
+        # Raise an error if any migrations are applied before their dependencies.
+        executor.loader.check_consistent_history(connection)
+
+        # Before anything else, see if there's conflicting apps and drop out
+        # hard if there are any
+        conflicts = executor.loader.detect_conflicts()
+        if conflicts:
+            name_str = "; ".join(
+                "%s in %s" % (", ".join(names), app)
+                for app, names in conflicts.items()
+            )
+            raise CommandError(
+                "Conflicting migrations detected; multiple leaf nodes in the "
+                "migration graph: (%s).\nTo fix them run "
+                "'python manage.py makemigrations --merge'" % name_str
+            )
+
+        # If they supplied command line arguments, work out what they mean.
+        run_syncdb = options['run_syncdb']
+        target_app_labels_only = True
+        if options['app_label']:
+            # Validate app_label.
+            app_label = options['app_label']
+            try:
+                apps.get_app_config(app_label)
+            except LookupError as err:
+                raise CommandError(str(err))
+            if run_syncdb:
+                if app_label in executor.loader.migrated_apps:
+                    raise CommandError("Can't use run_syncdb with app '%s' as it has migrations." % app_label)
+            elif app_label not in executor.loader.migrated_apps:
+                raise CommandError("App '%s' does not have migrations." % app_label)
+
+        if options['app_label'] and options['migration_name']:
+            migration_name = options['migration_name']
+            if migration_name == "zero":
+                targets = [(app_label, None)]
+            else:
+                try:
+                    migration = executor.loader.get_migration_by_prefix(app_label, migration_name)
+                except AmbiguityError:
+                    raise CommandError(
+                        "More than one migration matches '%s' in app '%s'. "
+                        "Please be more specific." %
+                        (migration_name, app_label)
+                    )
+                except KeyError:
+                    raise CommandError("Cannot find a migration matching '%s' from app '%s'." % (
+                        migration_name, app_label))
+                targets = [(app_label, migration.name)]
+            target_app_labels_only = False
+        elif options['app_label']:
+            targets = [key for key in executor.loader.graph.leaf_nodes() if key[0] == app_label]
+        else:
+            targets = executor.loader.graph.leaf_nodes()
+
+        plan = executor.migration_plan(targets)
+
+        if options['plan']:
+            self.stdout.write('Planned operations:', self.style.MIGRATE_LABEL)
+            if not plan:
+                self.stdout.write('  No planned migration operations.')
+            for migration, backwards in plan:
+                self.stdout.write(str(migration), self.style.MIGRATE_HEADING)
+                for operation in migration.operations:
+                    message, is_error = self.describe_operation(operation, backwards)
+                    style = self.style.WARNING if is_error else None
+                    self.stdout.write('    ' + message, style)
+            return
+
+        # At this point, ignore run_syncdb if there aren't any apps to sync.
+        run_syncdb = options['run_syncdb'] and executor.loader.unmigrated_apps
+        # Print some useful info
+        if self.verbosity >= 1:
+            self.stdout.write(self.style.MIGRATE_HEADING("Operations to perform:"))
+            if run_syncdb:
+                if options['app_label']:
+                    self.stdout.write(
+                        self.style.MIGRATE_LABEL("  Synchronize unmigrated app: %s" % app_label)
+                    )
+                else:
+                    self.stdout.write(
+                        self.style.MIGRATE_LABEL("  Synchronize unmigrated apps: ") +
+                        (", ".join(sorted(executor.loader.unmigrated_apps)))
+                    )
+            if target_app_labels_only:
+                self.stdout.write(
+                    self.style.MIGRATE_LABEL("  Apply all migrations: ") +
+                    (", ".join(sorted({a for a, n in targets})) or "(none)")
+                )
+            else:
+                if targets[0][1] is None:
+                    self.stdout.write(self.style.MIGRATE_LABEL(
+                        "  Unapply all migrations: ") + "%s" % (targets[0][0],)
+                    )
+                else:
+                    self.stdout.write(self.style.MIGRATE_LABEL(
+                        "  Target specific migration: ") + "%s, from %s"
+                        % (targets[0][1], targets[0][0])
+                    )
+
+        pre_migrate_state = executor._create_project_state(with_applied_migrations=True)
+        pre_migrate_apps = pre_migrate_state.apps
+        emit_pre_migrate_signal(
+            self.verbosity, self.interactive, connection.alias, apps=pre_migrate_apps, plan=plan,
+        )
+
+        # Run the syncdb phase.
+        if run_syncdb:
+            if self.verbosity >= 1:
+                self.stdout.write(self.style.MIGRATE_HEADING("Synchronizing apps without migrations:"))
+            if options['app_label']:
+                self.sync_apps(connection, [app_label])
+            else:
+                self.sync_apps(connection, executor.loader.unmigrated_apps)
+
+        # Migrate!
+        if self.verbosity >= 1:
+            self.stdout.write(self.style.MIGRATE_HEADING("Running migrations:"))
+        if not plan:
+            if self.verbosity >= 1:
+                self.stdout.write("  No migrations to apply.")
+                # If there's changes that aren't in migrations yet, tell them how to fix it.
+                autodetector = MigrationAutodetector(
+                    executor.loader.project_state(),
+                    ProjectState.from_apps(apps),
+                )
+                changes = autodetector.changes(graph=executor.loader.graph)
+                if changes:
+                    self.stdout.write(self.style.NOTICE(
+                        "  Your models have changes that are not yet reflected "
+                        "in a migration, and so won't be applied."
+                    ))
+                    self.stdout.write(self.style.NOTICE(
+                        "  Run 'manage.py makemigrations' to make new "
+                        "migrations, and then re-run 'manage.py migrate' to "
+                        "apply them."
+                    ))
+            fake = False
+            fake_initial = False
+        else:
+            fake = options['fake']
+            fake_initial = options['fake_initial']
+        post_migrate_state = executor.migrate(
+            targets, plan=plan, state=pre_migrate_state.clone(), fake=fake,
+            fake_initial=fake_initial,
+        )
+        # post_migrate signals have access to all models. Ensure that all models
+        # are reloaded in case any are delayed.
+        post_migrate_state.clear_delayed_apps_cache()
+        post_migrate_apps = post_migrate_state.apps
+
+        # Re-render models of real apps to include relationships now that
+        # we've got a final state. This wouldn't be necessary if real apps
+        # models were rendered with relationships in the first place.
+        with post_migrate_apps.bulk_update():
+            model_keys = []
+            for model_state in post_migrate_apps.real_models:
+                model_key = model_state.app_label, model_state.name_lower
+                model_keys.append(model_key)
+                post_migrate_apps.unregister_model(*model_key)
+        post_migrate_apps.render_multiple([
+            ModelState.from_model(apps.get_model(*model)) for model in model_keys
+        ])
+
+        # Send the post_migrate signal, so individual apps can do whatever they need
+        # to do at this point.
+        emit_post_migrate_signal(
+            self.verbosity, self.interactive, connection.alias, apps=post_migrate_apps, plan=plan,
+        )

--- a/gravity/tilt/tilt_monitor_aio.py
+++ b/gravity/tilt/tilt_monitor_aio.py
@@ -96,10 +96,15 @@ def processBLEBeacon(data):
     # ev.show(0)
 
     try:
+        mac_addr = ev.retrieve("peer")[0].val
+    except:
+        pass
+
+    try:
         # Let's use some of the functions of aioblesscan to tease out the mfg_specific_data payload
 
-        data = ev.retrieve("Manufacturer Specific Data")
-        payload = data[0].payload
+        manufacturer_data = ev.retrieve("Manufacturer Specific Data")
+        payload = manufacturer_data[0].payload
         payload = payload[1].val.hex()
 
         # ...and then dissect said payload into a UUID, temp, and gravity
@@ -120,6 +125,9 @@ def processBLEBeacon(data):
 
     color = TiltHydrometer.color_lookup(uuid)  # Map the uuid back to our TiltHydrometer object
     tilts[color].process_decoded_values(gravity, temp, rssi)  # Process the data sent from the Tilt
+
+    #print("Color {} - MAC {}".format(color, mac_addr))
+    #print("Raw Data: `{}`".format(raw_data_hex))
 
     # The Fermentrack specific stuff:
     reload = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Django>=3.0.5,<3.1
 configobj       # required by brewpi.py
 
 pyzmq~=19.0.1 --no-binary=pyzmq  # The wheel for pyzmq periodically has issues for Raspbian installs
+# numpy==1.18.4 --no-binary=numpy  # The wheel for numpy also has issues (at least on Stretch)
 
 pytz            # required by manage.py migrate
 sentry-sdk      # used for debugging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 Django>=3.0.5,<3.1
 configobj       # required by brewpi.py
 
+pyzmq~=19.0.1 --no-binary=pyzmq  # The wheel for pyzmq periodically has issues for Raspbian installs
+
 pytz            # required by manage.py migrate
 sentry-sdk      # used for debugging
 django-constance[database]  # for managing user-configured constants
@@ -19,7 +21,6 @@ requests        # for loading firmware data from websites
 esptool         # for flashing ESP8266 devices
 packaging~=17.1 # for testing requirements in the Tilt tests
 
-pyzmq~=19.0.1 --no-binary=pyzmq  # The wheel for pyzmq periodically has issues for Raspbian installs
 
 # Reminder - Update the version checks in gravity/tilt/tilt_tests.py when changing versions for the BT/Tilt pkgs
 redis==3.4.1           # for huey & gravity sensor support

--- a/utils/fix_sqlite_for_django_2.sh
+++ b/utils/fix_sqlite_for_django_2.sh
@@ -36,8 +36,10 @@ printerror() {
 }
 
 
-
-exec > >(tee -i log/upgrade.log)
+# Nuke the upgrade log before we attempt
+touch log/upgrade.log
+truncate --size=0 log/upgrade.log
+exec > >(tee -i -a log/upgrade.log)
 
 
 printinfo "Running fix_sqlite_for_django_2 management command"


### PR DESCRIPTION
This PR adds a new management command - `migrate_no_fk` which is the same as `manage.py migrate` except that it disables foreign key checks.

This helps resolve an issue where the `fix_sqlite_for_django_2` command could not be run if all migrations had not been applied prior to the migration to Django 2.0+.