### PR TITLE
Cater for different state index when gravity device is active

### DIFF
--- a/app/templates/device_dashboard.html
+++ b/app/templates/device_dashboard.html
@@ -603,6 +603,15 @@ const stateToName = state => (({
     4: 'cooling',
 })[state] || 'other');
 
+// The index of the state in the record returned from the API can changes, depending on
+// whether a gravity device is enabled.  Ideally, the gravity data should be added to the
+// end of the record instead of before the state.
+{% if beer.gravity_enabled %}
+const stateIndex = 8;
+{% else %}
+const stateIndex = 6;
+{% endif %}
+
 const computeDutyCycles = () => {
     const [minDate, maxDate] = g2.xAxisRange();
     const minIdx = g2.rawData_
@@ -620,7 +629,7 @@ const computeDutyCycles = () => {
     const result = visibleData.reduce((acc, row, idx, arr) => {
         if (idx === 0) return acc;
 
-        const currentStateName = stateToName(row[6])
+        const currentStateName = stateToName(row[stateIndex])
         
         if (currentStateName === acc.lastState) {
             acc[currentStateName] += row[0] - arr[idx - 1][0];
@@ -633,7 +642,7 @@ const computeDutyCycles = () => {
         heating: 0,
         cooling: 0,
         other: 0,
-        lastState: stateToName(visibleData[0][6]),
+        lastState: stateToName(visibleData[0][stateIndex]),
     });
 
     const heatingMinutes = Math.round(result.heating / 1000 / 60);


### PR DESCRIPTION
SImple fix for https://github.com/thorrak/fermentrack/issues/504 (broken state on device dashboard when gravity device is enabled)

A more comprehensive fix would be to re-arrange the data coming back from the server to leave state at index 6, and add gravity device details at 7 and 8, but this would probably require more change elsewhere.