### PR TITLE
Dark Mode

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -35,7 +35,7 @@ jobs:
         name: Build dockerfile (armv7/amd64/arm64)
         run: |
           docker buildx build \
-          --platform=linux/arm/v7,linux/amd64 \
+          --platform=linux/arm/v7,linux/amd64,linux/i386 \
           --output "type=image,push=true" \
           --file ./compose/production/django/Dockerfile . \
           --tag jdbeeler/fermentrack:latest

--- a/app/setup_forms.py
+++ b/app/setup_forms.py
@@ -55,7 +55,7 @@ class GuidedSetupConfigForm(forms.Form):
         (True, 'Yes'),
         (False, 'No')
     ]
-    theme_select = settings.CONSTANCE_ADDITIONAL_FIELDS['theme_select'][1]['choices']
+    theme_select = settings.CONSTANCE_ADDITIONAL_FIELDS['custom_theme_select'][1]['choices']
 
     update_options = settings.CONSTANCE_ADDITIONAL_FIELDS['git_update_type_select'][1]['choices'][1:]
 
@@ -65,9 +65,7 @@ class GuidedSetupConfigForm(forms.Form):
     # database table hasn't been created yet (ie - at initial setup)
     brewery_name = forms.CharField()  # initial=config.BREWERY_NAME
 
-    custom_theme = forms.ChoiceField(
-        choices=theme_select,
-        )
+    custom_theme = forms.ChoiceField(choices=theme_select)
 
     date_time_format_display = forms.ChoiceField(  # initial=config.DATE_TIME_FORMAT_DISPLAY
         choices=date_time_display_select_choices,

--- a/app/setup_forms.py
+++ b/app/setup_forms.py
@@ -55,6 +55,7 @@ class GuidedSetupConfigForm(forms.Form):
         (True, 'Yes'),
         (False, 'No')
     ]
+    theme_select = settings.CONSTANCE_ADDITIONAL_FIELDS['theme_select'][1]['choices']
 
     update_options = settings.CONSTANCE_ADDITIONAL_FIELDS['git_update_type_select'][1]['choices'][1:]
 
@@ -63,6 +64,10 @@ class GuidedSetupConfigForm(forms.Form):
     # There appears to be a bug with constance where if you use config in a form setup it will die if the constance
     # database table hasn't been created yet (ie - at initial setup)
     brewery_name = forms.CharField()  # initial=config.BREWERY_NAME
+
+    custom_theme = forms.ChoiceField(
+        choices=theme_select,
+        )
 
     date_time_format_display = forms.ChoiceField(  # initial=config.DATE_TIME_FORMAT_DISPLAY
         choices=date_time_display_select_choices,
@@ -109,6 +114,7 @@ class GuidedSetupConfigForm(forms.Form):
 
         self.fields['brewery_name'].initial = config.BREWERY_NAME
         self.fields['brewery_name'].help_text = config.BREWERY_NAME
+        self.fields['custom_theme'].initial = config.CUSTOM_THEME
         self.fields['date_time_format_display'].initial = config.DATE_TIME_FORMAT_DISPLAY
         self.fields['require_login_for_dashboard'].initial = config.REQUIRE_LOGIN_FOR_DASHBOARD
         self.fields['temperature_format'].initial = config.TEMPERATURE_FORMAT

--- a/app/setup_views.py
+++ b/app/setup_views.py
@@ -76,6 +76,7 @@ def setup_config(request):
         if form.is_valid():
             f = form.cleaned_data
             config.BREWERY_NAME = f['brewery_name']
+            config.CUSTOM_THEME = f['custom_theme']
             config.DATE_TIME_FORMAT_DISPLAY = f['date_time_format_display']
             config.REQUIRE_LOGIN_FOR_DASHBOARD = f['require_login_for_dashboard']
             config.TEMPERATURE_FORMAT = f['temperature_format']

--- a/app/static/css/nord.fermentrack.css
+++ b/app/static/css/nord.fermentrack.css
@@ -1,0 +1,176 @@
+/* Nord Theme for Fermentrack */
+/* Default Colors from https://github.com/arcticicestudio/nord */
+:root {
+    --bgcolor: #2e3440; /* Background color of the page */
+    --textcolor: #e5e9f0; /* Main text color */
+    --linkcolor: #88c0d0; /* Link color */
+    --linkhover: #8fbcbb; /* Link color when hovering */
+    --navbgcolor: #3b4252; /* Navigation bar background color */
+    --bgsensorbox: #d08770; /* Sensor box background color */
+    --bgsgbox: #b48ead; /* Specific gravity box background color */
+    --bgabvbox: #4c566a; /* ABV box background color */
+    --bgtempbox: #5e81ac; /* Temperature box background color */
+    --bgtempconbox: #81a1c1; /* Temperature control box background color */
+    --graphlabels: #eceff4; /* Graph axis text color */
+    --bgdatapt: #bf616a; /* Add data point button background color */
+    --bgconbut: #88c0d0; /* Control logging button background color */
+    --bgprior: #a3be8c; /* Load prior log button background color */
+    --bgalert: #a3be8c; /* Pop-up alert background color */
+    --borderalert: #a3be8c; /* Pop-up alert border color */
+    --textalert: #e5e9f0; /* Pop-up alert text color */
+    --bghovermenu: #88c0d0; /* Menu hover color */
+    --legendrow: #4c566a; /* Legend row background color */
+    --bordercolor: #d8dee9; /* Border color for legend row */
+    --caret: #4c566a; /* Menu caret color */
+  }
+
+
+/* Overall colors */
+body{
+    color: var(--textcolor);
+    background-color: var(--bgcolor);
+}
+
+/* Link colors */
+a {
+    color: var(--linkcolor);
+}
+
+a:hover, a:focus {
+    color: var(--linkhover);
+}
+
+/* Background color of the navigation bar */
+.navbar-inverse {
+    background-color: var(--navbgcolor);
+}
+
+/* Drop down menu from navigation bar */
+.navbar-inverse .navbar-nav>.open>.dropdown-menu {
+    background-color: var(--navbgcolor);
+}
+
+.navbar-inverse .navbar-brand {
+    color: var(--textcolor);
+}
+
+.navbar-inverse .navbar-nav>li>a {
+    color: var(--textcolor);
+}
+
+.navbar-inverse .navbar-nav>li>a:hover, .navbar-inverse .navbar-nav>li>a:focus {
+    color: var(--linkhover);
+}
+
+.navbar-inverse .navbar-nav>.open>a, .navbar-inverse .navbar-nav>.open>a:hover, .navbar-inverse .navbar-nav>.open>a:focus {
+    color: var(--textcolor);
+    background-color: var(--linkhover);
+}
+
+.navbar-inverse .navbar-nav>.dropdown>a:hover .caret, .navbar-inverse .navbar-nav>.dropdown>a:focus .caret {
+    border-top-color: var(--linkhover);
+    border-bottom-color: var(--linkhover);
+}
+
+.navbar-inverse .navbar-brand:hover, .navbar-inverse .navbar-brand:focus {
+    color: var(--linkhover);
+    background-color: transparent;
+}
+
+.navbar-inverse .navbar-nav>.dropdown>a .caret {
+    border-top-color: var(--caret);
+    border-bottom-color: var(--caret);
+}
+
+.navbar-inverse .navbar-nav>.open>.dropdown-menu>li>a:hover,
+.navbar-inverse .navbar-nav>.open>.dropdown-menu>li>a:focus {
+	color: var(--textcolor);
+	background-color: var(--linkhover)
+}
+
+/* Gravity Sensor Box */
+.bg-carrot {
+    background: var(--bgsensorbox)!important;
+}
+
+/* SG Box */
+.bg-amethyst {
+    background: var(--bgsgbox)!important;
+}
+
+/* ABV Box */
+.bg-wet-asphalt {
+    background: var(--bgabvbox)!important;
+}
+
+/* Temperature Box */
+.bg-petermann {
+    background: var(--bgtempbox)!important;
+}
+
+/* Temp Controller Box */
+.bg-concrete {
+    background: var(--bgtempconbox)!important;
+}
+
+/* Graph colors */
+.dygraph-axis-label {
+    color: var(--graphlabels);
+}
+
+/* Bottom Buttons */
+.btn-danger {
+    background-color: var(--bgdatapt);
+}
+
+.btn-info {
+    background-color: var(--bgconbut);
+}
+
+.btn-success {
+    background-color: var(--bgprior);
+}
+
+/* Buttons (e.g. login, etc.) */
+.btn-primary:hover, .btn-primary.hover, .btn-primary:focus, .btn-primary:active, .btn-primary.active, .open>.dropdown-toggle.btn-primary {
+    color: var(--textcolor);
+    background-color: var(--bghovermenu);
+    border-color: var(--bghovermenu);
+}
+
+.btn-primary {
+    color: var(--textcolor);
+    background-color: var(--bgprior);
+}
+
+/* Alert pop-up */
+.alert-success {
+    color: var(--textcolor);
+    background-color: var(--bgalert);
+    border-color: var(--bgalert);
+}
+
+.panel-red > .panel-heading {
+    border-color: var(--bgdatapt);
+    color: var(--textcolor);
+    background-color: var(--bgdatapt);
+}
+
+.panel-red {
+    border-color: var(--bgdatapt);
+    background-color: var(--legendrow);
+}
+
+.chart-legend-row {
+    background-color: var(--legendrow);
+    border-top: 1px solid #ddd;
+}
+
+.form-control, .select2-search input[type=text] {
+    border: 2px solid var(--bordercolor);
+}
+
+.panel-footer {
+    background-color: var(--legendrow);
+    border-top: 1px solid #ddd;
+}

--- a/app/templates/setup/constance_app_configuration.html
+++ b/app/templates/setup/constance_app_configuration.html
@@ -24,6 +24,7 @@
         {% form_generic form.enable_gravity_support %}
         {% form_generic form.gravity_display_format %}
         {% form_generic form.update_preference %}
+        {% form_generic form.custom_theme %}
         {% form_generic form.enable_sentry_support %}
         <input type="submit" value="Save Configuration" class="btn btn-primary"/>
     </div>

--- a/app/templates/sitewide/flat_ui_template.html
+++ b/app/templates/sitewide/flat_ui_template.html
@@ -17,7 +17,10 @@
         {# TODO - Move dygraph out to only the pages that use it #}
         <script type="text/javascript" src="{% static "vendor/dygraph/js/dygraph.min.js" %}"></script>
         <link src="{% static "vendor/dygraph/css/dygraph.css" %}" rel="stylesheet">
-
+        {% if config.CUSTOM_THEME == 'nord' %}
+        <link href="{% static "css/nord.fermentrack.css" %}" rel="stylesheet">
+        {% endif %}
+                
         <!-- HTML5 shim, for IE6-8 support of HTML5 elements. -->
         <!--[if lt IE 9]>
           <script src="{% static "vendor/other/js/html5shiv.js" %}"></script>

--- a/app/views.py
+++ b/app/views.py
@@ -615,6 +615,7 @@ def site_settings(request):
         if form.is_valid():
             f = form.cleaned_data
             config.BREWERY_NAME = f['brewery_name']
+            config.CUSTOM_THEME = f['custom_theme']
             config.DATE_TIME_FORMAT_DISPLAY = f['date_time_format_display']
             config.REQUIRE_LOGIN_FOR_DASHBOARD = f['require_login_for_dashboard']
             config.TEMPERATURE_FORMAT = f['temperature_format']

--- a/docs/source/develop/changelog.rst
+++ b/docs/source/develop/changelog.rst
@@ -9,6 +9,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) because it
 [Unreleased] - Bugfixes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+Added
+---------------------
+
+- i386 (i686) build target for Docker images
+- Custom color scheme support (dark mode!) (Thanks @calandryll!)
+
+
 Fixed
 -----
 

--- a/fermentrack_django/settings.py
+++ b/fermentrack_django/settings.py
@@ -216,6 +216,10 @@ CONSTANCE_ADDITIONAL_FIELDS = {
         'widget': 'django.forms.Select',
         'choices': [(x,x) for x in pytz.common_timezones]
     }],
+    'custom_theme_select': ['django.forms.fields.ChoiceField', {
+        'widget': 'django.forms.Select',
+        'choices': [('default', "Default (light) Color Theme"), ('nord', "Nord (dark) Color Theme")]
+    }],
 }
 
 # CONSTANCE_SUPERUSER_ONLY = False
@@ -249,13 +253,14 @@ CONSTANCE_CONFIG = {
     'GRAPH_GRAVITY_TEMP_COLOR': ("#280003", 'What color do you want the gravity sensor temperature line on the graph?', str),
     'SQLITE_OK_DJANGO_2': (False, 'Has the Django 2.0+ SQLite migration been run?',
                                    bool),
+    'CUSTOM_THEME': ('default', 'What color theme would you like to use for Fermentrack?', 'custom_theme_select'),
 
 }
 
 CONSTANCE_CONFIG_FIELDSETS = {
     'General Options': ('BREWERY_NAME', 'DATE_TIME_FORMAT_DISPLAY', 'REQUIRE_LOGIN_FOR_DASHBOARD', 'TEMPERATURE_FORMAT',
                         'TEMP_CONTROL_SUPPORT_ENABLED', 'GRAVITY_SUPPORT_ENABLED', 'PREFERRED_TIMEZONE',
-                        'GRAVITY_DISPLAY_FORMAT'),
+                        'GRAVITY_DISPLAY_FORMAT', 'CUSTOM_THEME'),
 
     'Graph Colors': ('GRAPH_BEER_TEMP_COLOR', 'GRAPH_BEER_SET_COLOR', 'GRAPH_FRIDGE_TEMP_COLOR',
                      'GRAPH_FRIDGE_SET_COLOR', 'GRAPH_ROOM_TEMP_COLOR', 'GRAPH_GRAVITY_COLOR',


### PR DESCRIPTION
Thanks to @calandryll 's work, Fermentrack can now have a "dark mode" theme selected from the configuration page. This effectively adds the feature @jnr-nat requested in #507 (even though that issue was closed)

Thanks again @calandryll -- this is awesome!