### PR TITLE
Darker dark mode

### DIFF
--- a/app/static/css/nord.fermentrack.css
+++ b/app/static/css/nord.fermentrack.css
@@ -166,6 +166,10 @@ a:hover, a:focus {
     border-top: 1px solid #ddd;
 }
 
+.table-striped>tbody>tr:nth-of-type(odd) {
+    background-color: var(--bgcolor);
+}
+
 .form-control, .select2-search input[type=text] {
     border: 2px solid var(--bordercolor);
 }

--- a/app/static/css/nord.fermentrack.css
+++ b/app/static/css/nord.fermentrack.css
@@ -176,6 +176,10 @@ a:hover, a:focus {
     color: var(--textcolor);
 }
 
+.list-group-item {
+    background-color: var(--legendrow);
+}
+
 .panel-footer {
     background-color: var(--legendrow);
     border-top: 1px solid #ddd;

--- a/app/static/css/nord.fermentrack.css
+++ b/app/static/css/nord.fermentrack.css
@@ -193,6 +193,10 @@ pre {
     background-color: var(--inputfield);
 }
 
+.modal-content {
+    background-color: var(--bgcolor);
+}
+
 .panel-footer {
     background-color: var(--legendrow);
     border-top: 1px solid #ddd;

--- a/app/static/css/nord.fermentrack.css
+++ b/app/static/css/nord.fermentrack.css
@@ -20,6 +20,7 @@
     --textalert: #e5e9f0; /* Pop-up alert text color */
     --bghovermenu: #88c0d0; /* Menu hover color */
     --legendrow: #4c566a; /* Legend row background color */
+    --inputfield: #4c566a; /* Input field background color */
     --bordercolor: #d8dee9; /* Border color for legend row */
     --caret: #4c566a; /* Menu caret color */
   }
@@ -178,6 +179,18 @@ a:hover, a:focus {
 
 .list-group-item {
     background-color: var(--legendrow);
+}
+
+textarea {
+    background-color: var(--inputfield);
+}
+
+input {
+    background-color: var(--inputfield);
+}
+
+pre {
+    background-color: var(--inputfield);
 }
 
 .panel-footer {

--- a/app/static/css/nord.fermentrack.css
+++ b/app/static/css/nord.fermentrack.css
@@ -172,6 +172,8 @@ a:hover, a:focus {
 
 .form-control, .select2-search input[type=text] {
     border: 2px solid var(--bordercolor);
+    background-color: var(--legendrow);
+    color: var(--textcolor);
 }
 
 .panel-footer {

--- a/app/templates/brewpi/temp_control_modal.html
+++ b/app/templates/brewpi/temp_control_modal.html
@@ -5,7 +5,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="myModalLabel" style="color: #000;">Set Temp Control for {{ this_device.device_name }}</h4>
+        <h4 class="modal-title" id="myModalLabel">Set Temp Control for {{ this_device.device_name }}</h4>
       </div>
 
 

--- a/app/templates/device_dashboard.html
+++ b/app/templates/device_dashboard.html
@@ -303,7 +303,7 @@
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 {% if not active_device.active_beer %}
     {# Modal for when nothing is logging (start logging) #}
-                <h4 class="modal-title" id="beerModalLabel" style="color: #000;">Create Beer & Start Logging</h4>
+                <h4 class="modal-title" id="beerModalLabel">Create Beer & Start Logging</h4>
             </div>
 
 
@@ -324,7 +324,7 @@
             </div>
 {% else %}
     {# Modal for when logging is active (pause/end buttons) #}
-                <h4 class="modal-title" id="beerModalLabel" style="color: #000;">Beer Logging Control</h4>
+                <h4 class="modal-title" id="beerModalLabel">Beer Logging Control</h4>
             </div>
 
 

--- a/gravity/templates/gravity/gravity_dashboard.html
+++ b/gravity/templates/gravity/gravity_dashboard.html
@@ -237,7 +237,7 @@
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 {% if active_device.assigned_brewpi_device %}
     {# Modal for when there is an attached device #}
-                <h4 class="modal-title" id="logModalLabel" style="color: #000;">Attached to Device</h4>
+                <h4 class="modal-title" id="logModalLabel">Attached to Device</h4>
             </div>
 
 
@@ -266,7 +266,7 @@
 
 {% elif not active_device.active_log %}
     {# Modal for when nothing is logging (start logging) -- and we aren't attached to a temperature controller #}
-                <h4 class="modal-title" id="logModalLabel" style="color: #000;">Start Logging</h4>
+                <h4 class="modal-title" id="logModalLabel">Start Logging</h4>
             </div>
 
 

--- a/gravity/templates/gravity/gravity_manage_ispindel.html
+++ b/gravity/templates/gravity/gravity_manage_ispindel.html
@@ -119,7 +119,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h4 class="modal-title" id="myModalLabel" style="color: #000;">Add calibration point to {{ active_device.name }}</h4>
+            <h4 class="modal-title" id="myModalLabel">Add calibration point to {{ active_device.name }}</h4>
           </div>
 
 

--- a/gravity/templates/gravity/gravity_manage_tilt.html
+++ b/gravity/templates/gravity/gravity_manage_tilt.html
@@ -206,7 +206,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h4 class="modal-title" id="myModalLabel" style="color: #000;">Add calibration point to {{ active_device.name }}</h4>
+            <h4 class="modal-title" id="myModalLabel">Add calibration point to {{ active_device.name }}</h4>
           </div>
 
 


### PR DESCRIPTION
Several elements in dark mode were inconsistent with the theme or still had white backgrounds that were unreadable; for example the chart legend:
![dark_table_striped](https://user-images.githubusercontent.com/10291736/161591430-290b3a5e-093d-493d-85b1-2c99d05047d7.png)

Gets changed to:

![2022-04-04 11 42 57 192 168 2 250 3fc358b5c9d8](https://user-images.githubusercontent.com/10291736/161591739-21ff678d-b083-4241-988b-9002b7c0cb2a.png)

