### PR TITLE
Refactor communication between script caller & Fermentrack

### DIFF
--- a/.github/workflows/docker-hub-test.yml
+++ b/.github/workflows/docker-hub-test.yml
@@ -3,7 +3,7 @@ name: 'Build & Push to Docker Hub (Testing)'
 on:
   push:
     branches:
-      - script
+      - dev_api
 
 jobs:
   buildx:

--- a/app/api/devices.py
+++ b/app/api/devices.py
@@ -1,0 +1,11 @@
+from django.http import JsonResponse
+from django.urls import reverse
+from constance import config
+
+from app.models import BrewPiDevice
+
+
+def get_devices(req):
+    active_devices = list(BrewPiDevice.objects.filter(status=BrewPiDevice.STATUS_ACTIVE).values_list('id', flat=True))
+    return JsonResponse(active_devices, safe=False, json_dumps_params={'indent': 4})
+

--- a/brewpi-script/fermentrack_config_loader.py
+++ b/brewpi-script/fermentrack_config_loader.py
@@ -4,6 +4,7 @@
 import os
 import sys
 from pathlib import Path
+from time import sleep
 from typing import List
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -196,6 +197,10 @@ class FermentrackBrewPiScriptConfig(BrewPiScriptConfig):
 
 
 def get_active_brewpi_devices() -> List[int]:
-    active_devices = app.models.BrewPiDevice.objects.filter(status=app.models.BrewPiDevice.STATUS_ACTIVE
-                                                            ).values_list('id', flat=True)
+    try:
+        active_devices = app.models.BrewPiDevice.objects.filter(status=app.models.BrewPiDevice.STATUS_ACTIVE
+                                                                ).values_list('id', flat=True)
+    except:
+        sleep(5)
+        exit(1)
     return active_devices

--- a/brewpi-script/fermentrack_config_loader.py
+++ b/brewpi-script/fermentrack_config_loader.py
@@ -32,7 +32,7 @@ class FermentrackBrewPiScriptConfig(BrewPiScriptConfig):
             brewpi_device = app.models.BrewPiDevice.objects.get(id=self.brewpi_device_id)
         except ObjectDoesNotExist:
             return False  # cannot load the object from the database (deleted?)
-        except StopIteration:
+        except RuntimeError:
             return False
 
         self.brewpi_device = brewpi_device
@@ -86,6 +86,8 @@ class FermentrackBrewPiScriptConfig(BrewPiScriptConfig):
         try:
             is_past_end = self.brewpi_device.is_past_end_of_profile()
         except StopIteration:
+            is_past_end = False
+        except RuntimeError:
             is_past_end = False
         return is_past_end
 

--- a/brewpi-script/fermentrack_config_loader.py
+++ b/brewpi-script/fermentrack_config_loader.py
@@ -128,6 +128,10 @@ class FermentrackBrewPiScriptConfig(BrewPiScriptConfig):
             brewpi_devices = app.models.BrewPiDevice.objects.filter(wifi_host_ip=ip_to_save)
         except ObjectDoesNotExist:
             return  # cannot load the object from the database (deleted?)
+        except:
+            # To try to avoid the deadlocking
+            # TODO - Remove this catch-all
+            exit(1)
 
         for brewpi_device in brewpi_devices:
             brewpi_device.wifi_host_ip = None
@@ -169,6 +173,10 @@ class FermentrackBrewPiScriptConfig(BrewPiScriptConfig):
             brewpi_device = app.models.BrewPiDevice.objects.get(id=self.brewpi_device_id)
         except ObjectDoesNotExist:
             return  # cannot load the object from the database (deleted?)
+        except:
+            # To try to avoid the deadlocking
+            # TODO - Remove this catch-all
+            exit(1)
 
         new_log_point = app.models.BeerLogPoint()
 

--- a/fermentrack_django/urls.py
+++ b/fermentrack_django/urls.py
@@ -11,6 +11,7 @@ import app.setup_views
 import app.beer_views
 import app.api.lcd
 import app.api.clog
+import app.api.devices
 
 import firmware_flash.urls
 import gravity.urls
@@ -107,7 +108,7 @@ urlpatterns = [
     url(r'^api/log/(?P<return_type>text|json)/(?P<device_type>\w{1,20})/(?P<logfile>stdout|stderr)/$', app.api.clog.get_device_log_combined, name="get_app_log"),
     url(r'^api/log/(?P<return_type>text|json)/(?P<device_type>\w{1,20})/(?P<logfile>stdout|stderr)/l(?P<lines>\d{1,20})/$', app.api.clog.get_device_log_combined, name="get_app_log_lines"),
     # api/gravity views are located in the gravity app
-
+    url(r'^api/devices/$', app.api.devices.get_devices, name="getDevices"),  # For all devices/LCDs
 
     # Login/Logout Views
     url(r'^accounts/login/$', app.views.login, name='login'),  # This is also settings.LOGIN_URL


### PR DESCRIPTION
This PR should help stabilize Fermentrack script caller in certain instances where deadlocks were occurring as the database was getting hammered. This replaces the most commonly used database call with an HTTP interface that can be used to read the list of available controllers. 